### PR TITLE
Fix configuration

### DIFF
--- a/src/M6Web/Bundle/RedisBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/RedisBundle/DependencyInjection/Configuration.php
@@ -76,7 +76,7 @@ class Configuration implements ConfigurationInterface
                                 ->min(0)
                             ->end()
                             ->enumNode('type')
-                                ->values('cache', 'db', 'multi')
+                                ->values(['cache', 'db', 'multi'])
                                 ->defaultValue('cache')
                             ->end()
                             ->booleanNode('compress')->defaultFalse()->end()


### PR DESCRIPTION
Fix :

PHP Catchable fatal error:  Argument 1 passed to Symfony\Component\Config\Definition\Builder\EnumNodeDefinition::values() must be of the type array, string given, called in [...]vendor/m6web/redis-bundle/src/M6Web/Bundle/RedisBundle/DependencyInjection/Configuration.php on line 79
