### PR TITLE
Symfony 3 compatibilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "atoum/atoum":      "@stable",
         "m6web/redis-mock": "@stable",
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "~2.3|~3.0",
         "m6web/coke" : "~1.2",
         "m6web/symfony2-coding-standard" : "~1.1"
     },

--- a/src/M6Web/Bundle/RedisBundle/DependencyInjection/M6WebRedisExtension.php
+++ b/src/M6Web/Bundle/RedisBundle/DependencyInjection/M6WebRedisExtension.php
@@ -157,7 +157,6 @@ class M6WebRedisExtension extends Extension
                 throw new InvalidConfigurationException("Invalid client type");
         }
 
-        $definition->setScope(ContainerInterface::SCOPE_CONTAINER);
         $definition->addMethodCall('setEventDispatcher', array(new Reference('event_dispatcher'), 'M6Web\Bundle\RedisBundle\EventDispatcher\RedisEvent'));
 
         $container->setDefinition($serviceId, $definition);


### PR DESCRIPTION
Symfony 3 compatibilities :
- Scope is removed in DIC, use shared instead of scope