### PR TITLE
json_encode to fix profiler when array of array

### DIFF
--- a/src/M6Web/Bundle/RedisBundle/Resources/views/Collector/redis.html.twig
+++ b/src/M6Web/Bundle/RedisBundle/Resources/views/Collector/redis.html.twig
@@ -45,7 +45,7 @@
                 {% set time = command.executiontime %}
                 <td>{{ time }}</td>
                 <td>
-                    {{ command.arguments|join(', ') }}
+                    {{ command.arguments|json_encode }}
                 </td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
Why?
Because when I do a zrevrangebyscore and arguments are then 
```php
array (size=4)
  0 => string 'broadcastM620171211' (length=19)
  1 => int 1513035346
  2 => string '-inf' (length=4)
  3 => 
    array (size=1) <==== it fails here :(
      'LIMIT' => 
        array (size=2)
          0 => int 0
          1 => int 1
```
|join(', ') can't handle it.

How?
As we are all fluent in json, json_encode all the things! :)