### PR TITLE
add reset function

### DIFF
--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -33,6 +33,10 @@ class RedisDataCollector extends DataCollector
     {
     }
 
+    public function reset()
+    {
+    }
+    
     /**
      * Listen for redis command event
      *

--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -36,7 +36,7 @@ class RedisDataCollector extends DataCollector
     public function reset()
     {
     }
-    
+
     /**
      * Listen for redis command event
      *

--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -34,9 +34,9 @@ class RedisDataCollector extends DataCollector
     }
 
     public function reset() {
-      $this->data = [
-        'redis' => new \SplQueue(),
-      ];
+        $this->data = [
+            'redis' => new \SplQueue(),
+        ];
     }
 
     /**

--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -33,7 +33,8 @@ class RedisDataCollector extends DataCollector
     {
     }
 
-    public function reset() {
+    public function reset()
+    {
         $this->data = [
             'redis' => new \SplQueue(),
         ];

--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -19,7 +19,7 @@ class RedisDataCollector extends DataCollector
      */
     public function __construct()
     {
-        $this->data['redis'] = new \SplQueue();
+        $this->reset();
     }
 
     /**
@@ -33,8 +33,10 @@ class RedisDataCollector extends DataCollector
     {
     }
 
-    public function reset()
-    {
+    public function reset() {
+      $this->data = [
+        'redis' => new \SplQueue(),
+      ];
     }
 
     /**


### PR DESCRIPTION
Because
(1/1) FatalErrorException
Error: Class M6Web\Bundle\RedisBundle\DataCollector\RedisDataCollector contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::reset)