### PR TITLE
remove return type as it can be object or int

### DIFF
--- a/src/CacheAdapters/M6WebGuzzleHttp.php
+++ b/src/CacheAdapters/M6WebGuzzleHttp.php
@@ -12,7 +12,7 @@ use M6Web\Bundle\GuzzleHttpBundle\Cache\CacheInterface;
  */
 class M6WebGuzzleHttp extends RedisClient implements CacheInterface
 {
-    public function set($key, $value, $ttl = null): bool
+    public function set($key, $value, $ttl = null)
     {
         if (null !== $ttl) {
             return $this->setex($key, $ttl, $value);

--- a/src/CacheAdapters/M6WebGuzzleHttp.php
+++ b/src/CacheAdapters/M6WebGuzzleHttp.php
@@ -14,8 +14,8 @@ class M6WebGuzzleHttp extends RedisClient implements CacheInterface
 {
     public function set($key, $value, $ttl = null)
     {
-        if (null !== $ttl) {
-            return $this->setex($key, $ttl, $value);
+        if ($ttl) {
+            return parent::setex($key, $ttl, $value);
         }
 
         return parent::set($key, $value);
@@ -26,7 +26,7 @@ class M6WebGuzzleHttp extends RedisClient implements CacheInterface
         return parent::get($key);
     }
 
-    public function ttl($key): int
+    public function ttl($key)
     {
         return parent::ttl($key);
     }


### PR DESCRIPTION
Because
`  "message": "Type error: Return value of M6Web\\Bundle\\RedisBundle\\CacheAdapters\\M6WebGuzzleHttp::set() must be of the type boolean, object returned",
`
But also it can return a int
https://github.com/nrk/predis/blob/893215a1d4503466f2c7d0bb44f2bd42e3deac39/src/ClientInterface.php#L65
so I need to remove it ;)
