### PR TITLE
Add reset Function for version ~3.0

### DIFF
--- a/src/M6Web/Bundle/RedisBundle/DataCollector/RedisDataCollector.php
+++ b/src/M6Web/Bundle/RedisBundle/DataCollector/RedisDataCollector.php
@@ -15,7 +15,7 @@ class RedisDataCollector extends DataCollector
      */
     public function __construct()
     {
-        $this->data['redis'] = new \SplQueue();
+        $this->reset();
     }
 
     /**
@@ -81,5 +81,15 @@ class RedisDataCollector extends DataCollector
         $totalExecutionTime = $this->getTotalExecutionTime();
 
         return ($totalExecutionTime) ? ($totalExecutionTime / count($this->getCommands()) ) : 0;
+    }
+
+    /**
+     * Reset
+     */
+    public function reset()
+    {
+        $this->data = [
+            'redis' => new \SplQueue()
+        ];
     }
 }

--- a/src/M6Web/Bundle/RedisBundle/Tests/Units/CacheAdapters/RedisCacheItemPoolAdapter.php
+++ b/src/M6Web/Bundle/RedisBundle/Tests/Units/CacheAdapters/RedisCacheItemPoolAdapter.php
@@ -26,7 +26,7 @@ class RedisCacheItemPoolAdapter extends AbstractTest
                 $this->testedInstance->save($item)
             )
             ->then
-                ->boolean($this->testedInstance->hasItem('myKey'))
+                ->boolean((bool)$this->testedInstance->hasItem('myKey'))
                     ->isTrue()
                 ->object($item)
                     ->isInstanceof('Psr\Cache\CacheItemInterface')
@@ -34,7 +34,7 @@ class RedisCacheItemPoolAdapter extends AbstractTest
                     ->isEqualTo('myValue')
             ->if($this->testedInstance->deleteItem('myKey'))
             ->then
-                ->boolean($this->testedInstance->hasItem('myKey'))
+                ->boolean((bool)$this->testedInstance->hasItem('myKey'))
                     ->isFalse()
         ;
     }


### PR DESCRIPTION
Abstract class `DataCollector` implement `reset()` function. This one is not implemented on `redisDataCollection`. I just want to have this function for the version `3.0` of this bundle.