### PR TITLE
feat: Change returned value to valid float

### DIFF
--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -72,11 +72,13 @@ class RedisDataCollector extends DataCollector
 
     public function getTotalExecutionTime(): float
     {
-        return array_reduce(iterator_to_array($this->getCommands()), function ($time, $value) {
+        $result = array_reduce(iterator_to_array($this->getCommands()), function ($time, $value) {
             $time += $value['executiontime'];
 
             return $time;
         });
+
+        return $result ?? 0;
     }
 
     public function getAvgExecutionTime(): float


### PR DESCRIPTION
Why
------
When no redis command is executed, the function `getCommands()` returns `null` that creates an error because of the hint function

How
------
If returned value is `null` simply replace by `0`
