### PR TITLE
feat(SF5): update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # RedisBundle [![Build Status](https://travis-ci.org/M6Web/RedisBundle.png?branch=master)](https://travis-ci.org/M6Web/RedisBundle)
 
-symfony2 Bundle on top of predis
+symfony Bundle on top of predis
 
 see [predis/predis](https://github.com/nrk/predis)
 
 ## features
 
 * semantic configuration
-* sf2 event dispatcher integration
+* sf event dispatcher integration
 * session handler with redis storage : ```M6Web\Bundle\RedisBundle\Redis\RedisSessionHandler```
 * redis adapter for guzzle cache : ```M6Web\Bundle\RedisBundle\Guzzle\RedisCacheAdapter```
 * dataCollector for sf2 web profiler toolbar

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "m6web/redis-bundle",
     "type": "symfony-bundle",
-    "description" : "bundle sf2 on top of predis",
+    "description" : "bundle sf on top of predis",
     "authors": [
         {
             "name": "Olivier Mansour",
@@ -13,7 +13,7 @@
         "bin-dir": "bin"
     },
     "require": {
-        "php": ">=7.1",
+        "php": "^7.2.5",
         "predis/predis": "^1.1.1",
         "doctrine/cache": "~1.3",
         "b1rdex/predis-compressible": "^0.3.0"
@@ -22,7 +22,7 @@
         "m6web/php-cs-fixer-config": "^1.0",
         "atoum/atoum":      "@stable",
         "m6web/redis-mock": "@stable",
-        "symfony/symfony": "~4.2",
+        "symfony/symfony": "~5.0",
         "psr/cache": "~1.0"
     },
     "autoload": {

--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -25,11 +25,11 @@ class RedisDataCollector extends DataCollector
     /**
      * Collect the data
      *
-     * @param Request    $request   The request object
-     * @param Response   $response  The response object
-     * @param \Exception $exception An exception
+     * @param Request $request The request object
+     * @param Response $response The response object
+     * @param \Throwable|null $exception An exception
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null)
     {
     }
 


### PR DESCRIPTION
Avec la version `5` de Symfony, la `DataCollectorInterface` n'a plus la même signature du `collect()`. 

Pour pouvoir utiliser le bundle avec cette version, il faut donc mettre à jour la signature de la méthode en remplaçant le `Exception` par un `Throwable` ;) 

Le composer.json à été mis à jour pour spécifier que cette version n'est utilise que pour symfony >= 5, avec une mise à jour de la version de PHP, compatible avec le minimum requis pour symfony 5 (histoire d'être cohérent) 

![RedisBundle](https://user-images.githubusercontent.com/12815769/123945678-b1718880-d99e-11eb-86cc-1abd1f44edb9.png)
