### PR TITLE
Feat/sf5 fix event

### DIFF
--- a/src/EventDispatcher/RedisEvent.php
+++ b/src/EventDispatcher/RedisEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle\EventDispatcher;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Redis event

--- a/src/Redis/RedisClient.php
+++ b/src/Redis/RedisClient.php
@@ -6,8 +6,9 @@ namespace M6Web\Bundle\RedisBundle\Redis;
 
 use Predis\Client as PredisClient;
 use Predis\Command\CommandInterface;
-use Symfony\Component\EventDispatcher;
 use M6Web\Bundle\RedisBundle\EventDispatcher\RedisEvent;
+use Predis\Profile\Factory;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class RedisClient extends PredisClient
 {
@@ -16,7 +17,7 @@ class RedisClient extends PredisClient
     /**
      * event dispatcher
      *
-     * @var EventDispatcher
+     * @var EventDispatcherInterface
      */
     protected $eventDispatcher = null;
 
@@ -30,17 +31,17 @@ class RedisClient extends PredisClient
     /**
      * eventName to be dispatched
      *
-     * @var array
+     * @var string
      */
     protected $eventName;
 
     public function __construct($parameters, $options)
     {
-        \Predis\Profile\Factory::define('compression', 'M6Web\Bundle\RedisBundle\Profile\CompressionProfile');
+        Factory::define('compression', 'M6Web\Bundle\RedisBundle\Profile\CompressionProfile');
         parent::__construct($parameters, $options);
     }
 
-    public function setEventDispatcher(EventDispatcher\EventDispatcherInterface $eventDispacher): self
+    public function setEventDispatcher(EventDispatcherInterface $eventDispacher): self
     {
         $this->eventDispatcher = $eventDispacher;
 
@@ -73,9 +74,9 @@ class RedisClient extends PredisClient
             $event->setCommand($command->getId());
             $event->setExecutionTime($time);
             $event->setArguments($command->getArguments());
-            $this->eventDispatcher->dispatch(self::DEFAULT_EVENT, $event);
+            $this->eventDispatcher->dispatch($event,self::DEFAULT_EVENT);
             if (!is_null($this->eventName)) {
-                $this->eventDispatcher->dispatch($this->eventName, $event);
+                $this->eventDispatcher->dispatch($event, $this->eventName);
             }
         }
 


### PR DESCRIPTION
Bon, du coup @Oliboy50 tu avais bien raison, il n'y avait pas que ce que j'ai fait dans ma dernière PR à faire 😢 .

Le bundle était catché dans un catch qui ne levait aucune exception. Je n'avais pas vu le soucis (re-😭). #myBad

J'ai fixé ça ici 👇 . 
Les namespaces de l'eventDispatcher ont bien changé avec `SF5`, une exception était levée vu qu'ils n'étaient pas trouvés.  Et l'ordre des paramètres du dispatcher est devenu plus logique (`object`, `name`) au lieu de (`name`, `object`).