### PR TITLE
fix bundle typing for php 8.1 compatibility

### DIFF
--- a/src/M6WebRedisBundle.php
+++ b/src/M6WebRedisBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace M6Web\Bundle\RedisBundle;
 
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -17,7 +18,7 @@ class M6WebRedisBundle extends Bundle
      *
      * @return object DependencyInjection\M6WebStatsdExtension
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new DependencyInjection\M6WebRedisExtension();
     }

--- a/src/Tests/Units/M6WebRedisBundle.php
+++ b/src/Tests/Units/M6WebRedisBundle.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace M6Web\Bundle\RedisBundle\Tests\Units;
+
+use M6Web\Bundle\RedisBundle\M6WebRedisBundle as TestedM6WebRedisBundle;
+
+class M6WebRedisBundle extends AbstractTest
+{
+    protected TestedM6WebRedisBundle $bundle;
+
+    public function testGetContainerExtension(): void
+    {
+        $this->bundle = new TestedM6WebRedisBundle();
+        $this->assert
+            ->object($this->bundle->getContainerExtension())
+            ->isInstanceOf('M6Web\Bundle\RedisBundle\DependencyInjection\M6WebRedisExtension');
+    }
+}


### PR DESCRIPTION
## Why?
After trying to use the new version with php 8.1 i found out it was missing a return type on the bundle class
Didn't see the problem on my previous PR sorry about that

## What?
 - Added the return type 
 - Added a test to prevent future similar problems

